### PR TITLE
add helper for Graph Beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "lokka",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Hello Merill. 

I was not able to make Lokka understand I want to use Graph Beta, I have tried many prompts tell Lokka use Beta endpoint, or tell Lokka use example "beta/deviceManagement/configurationPolicies" to find all Intune Settings Catalog policies. But still it wants to use the v1.0. 

I have added helper function to use Beta, if the prompt contains some keywords with "Beta", and also handle the URLs if I manually mentioned use withich beta URL. 

Before the change:
![image](https://github.com/user-attachments/assets/a4c3bf46-cd02-4e2b-94c9-1cfd6251dc05)

After the change:
![image](https://github.com/user-attachments/assets/ae944477-16c8-427f-9250-f186948f13fe)


Regards, Sandy