### PR TITLE
Fix link formatting in FAQ documentation

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -25,7 +25,7 @@ Lokka is not a replacement for Copilot and is not affiliated with Microsoft.
 
 ## Can I use this in production?
 
-We recommend using Lokka in a test environment for exploration and testing purposes. The aim of this project is to provide a playground to expirement with using LLMs for Microsoft 365 administration tasks.
+We recommend using Lokka in a test environment for exploration and testing purposes. The aim of this project is to provide a playground to experiment with using LLMs for Microsoft 365 administration tasks.
 
 :::note
 
@@ -45,4 +45,4 @@ If you encounter any issues or have suggestions for improvements, please open an
 
 ### TypeError `[ERR_INVALID_ARG_TYPE]`: The "path" argument must be of type string. Received undefined
 
-Make sure you have the the latest version of Node.js installed (v22.10.0 or higher). See [MCP Sever issues](https://github.com/merill/lokka/issues/3) for other tips.
+Make sure you have the latest version of Node.js installed (v22.10.0 or higher). See [MCP Server issues](https://github.com/merill/lokka/issues/3) for other tips.

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -39,7 +39,7 @@ No, Lokka is not a Microsoft product and is not affiliated with Microsoft.
 
 ## How do I report issues?
 
-If you encounter any issues or have suggestions for improvements, please open an issue on the [GitHub repository](https://github.com/merill/lokka/issues].
+If you encounter any issues or have suggestions for improvements, please open an issue on the [GitHub repository](https://github.com/merill/lokka/issues).
 
 ## I'm seeing this error message, what should I do?
 


### PR DESCRIPTION
This pull request includes a minor documentation fix in the FAQ section, correcting the GitHub repository link so users can more easily report issues or suggest improvements.