### PR TITLE
Add multi-tenant support for app-only auth and tenantId parameter (closes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Traditional app-only authentication. You can use either certificate (recommended
 
 See [Install Guide](https://lokka.dev/docs/install) for more details on how to create an Entra app.
 
+> ⚠️ For app-only authentication, `TENANT_ID` must be a specific tenant GUID or verified domain. The values `common` and `organizations` are not supported by the Microsoft identity platform for the client credentials flow and Lokka will refuse to start with them.
+
 #### App-Only Auth with Certificate
 
 App only authentication using a PEM-encoded client certificate:
@@ -136,6 +138,19 @@ When using client-provided token mode:
 2. Use the `set-access-token` tool to provide a valid Microsoft Graph access token
 3. Use the `get-auth-status` tool to verify authentication status
 4. Refresh tokens as needed using `set-access-token`
+
+### Multi-tenant queries (`tenantId` parameter)
+
+The `Lokka-Microsoft` tool accepts an optional `tenantId` parameter so a single Lokka session can query multiple tenants without restarting:
+
+- **App-only modes** (client credentials, certificate): if your Entra app is registered as multi-tenant and admin consent has been granted in each target tenant, set `tenantId` to query each tenant transparently.
+- **Interactive mode**: if your user account is a guest (B2B) in another tenant, set `tenantId` to query that tenant. An additional sign-in prompt may appear the first time, depending on your browser SSO state.
+- **Client-provided token mode**: not supported (the supplied token is bound to one tenant).
+
+Example natural-language prompt to the agent:
+> *"Get `/organization` from tenant `contoso.onmicrosoft.com`, then from `fabrikam.onmicrosoft.com`."*
+
+See the [advanced install guide](https://lokka.dev/docs/install-advanced/) for full details.
 
 ## New Tools
 

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -66,6 +66,8 @@ Traditional app-only authentication. You can use either certificate (recommended
 
 See [Install Guide](https://lokka.dev/docs/install) for more details on how to create an Entra app.
 
+> ⚠️ For app-only authentication, `TENANT_ID` must be a specific tenant GUID or verified domain. The values `common` and `organizations` are not supported by the Microsoft identity platform for the client credentials flow and Lokka will refuse to start with them.
+
 #### App-Only Auth with Certificate
 
 App only authentication using a PEM-encoded client certificate:
@@ -136,6 +138,19 @@ When using client-provided token mode:
 2. Use the `set-access-token` tool to provide a valid Microsoft Graph access token
 3. Use the `get-auth-status` tool to verify authentication status
 4. Refresh tokens as needed using `set-access-token`
+
+### Multi-tenant queries (`tenantId` parameter)
+
+The `Lokka-Microsoft` tool accepts an optional `tenantId` parameter so a single Lokka session can query multiple tenants without restarting:
+
+- **App-only modes** (client credentials, certificate): if your Entra app is registered as multi-tenant and admin consent has been granted in each target tenant, set `tenantId` to query each tenant transparently.
+- **Interactive mode**: if your user account is a guest (B2B) in another tenant, set `tenantId` to query that tenant. An additional sign-in prompt may appear the first time, depending on your browser SSO state.
+- **Client-provided token mode**: not supported (the supplied token is bound to one tenant).
+
+Example natural-language prompt to the agent:
+> *"Get `/organization` from tenant `contoso.onmicrosoft.com`, then from `fabrikam.onmicrosoft.com`."*
+
+See the [advanced install guide](https://lokka.dev/docs/install-advanced/) for full details.
 
 ## New Tools
 

--- a/src/mcp/build/auth.js
+++ b/src/mcp/build/auth.js
@@ -103,7 +103,7 @@ export class AuthManager {
                     throw new Error("Client credentials mode requires tenantId, clientId, and clientSecret");
                 }
                 logger.info("Initializing Client Credentials authentication");
-                this.credential = new ClientSecretCredential(this.config.tenantId, this.config.clientId, this.config.clientSecret);
+                this.credential = new ClientSecretCredential(this.config.tenantId, this.config.clientId, this.config.clientSecret, { additionallyAllowedTenants: ['*'] });
                 break;
             case AuthMode.ClientProvidedToken:
                 logger.info("Initializing Client Provided Token authentication");
@@ -117,7 +117,7 @@ export class AuthManager {
                 this.credential = new ClientCertificateCredential(this.config.tenantId, this.config.clientId, {
                     certificatePath: this.config.certificatePath,
                     certificatePassword: this.config.certificatePassword
-                });
+                }, { additionallyAllowedTenants: ['*'] });
                 break;
             case AuthMode.Interactive:
                 // Use defaults if not provided
@@ -130,6 +130,7 @@ export class AuthManager {
                         tenantId: tenantId,
                         clientId: clientId,
                         redirectUri: this.config.redirectUri || LokkaDefaultRedirectUri,
+                        additionallyAllowedTenants: ['*'],
                     });
                 }
                 catch (error) {
@@ -138,6 +139,7 @@ export class AuthManager {
                     this.credential = new DeviceCodeCredential({
                         tenantId: tenantId,
                         clientId: clientId,
+                        additionallyAllowedTenants: ['*'],
                         userPromptCallback: (info) => {
                             console.log(`\n🔐 Authentication Required:`);
                             console.log(`Please visit: ${info.verificationUri}`);

--- a/src/mcp/build/main.js
+++ b/src/mcp/build/main.js
@@ -22,6 +22,27 @@ let graphClient = null;
 const useGraphBeta = process.env.USE_GRAPH_BETA !== 'false'; // Default to true unless explicitly set to 'false'
 const defaultGraphApiVersion = getDefaultGraphApiVersion();
 logger.info(`Graph API default version: ${defaultGraphApiVersion} (USE_GRAPH_BETA=${process.env.USE_GRAPH_BETA || 'undefined'})`);
+async function buildTenantSpecificGraphClient(tenantId) {
+    if (!authManager) {
+        throw new Error("Auth manager not initialized");
+    }
+    const mode = authManager.getAuthMode();
+    if (mode === AuthMode.ClientProvidedToken) {
+        throw new Error("The 'tenantId' parameter is not supported in client_provided_token mode (the supplied token is bound to a single tenant).");
+    }
+    const credential = authManager.getAzureCredential();
+    return Client.initWithMiddleware({
+        authProvider: {
+            getAccessToken: async () => {
+                const token = await credential.getToken("https://graph.microsoft.com/.default", { tenantId });
+                if (!token) {
+                    throw new Error(`Failed to acquire Graph token for tenant ${tenantId}`);
+                }
+                return token.token;
+            }
+        }
+    });
+}
 server.tool("Lokka-Microsoft", "A versatile tool to interact with Microsoft APIs including Microsoft Graph (Entra) and Azure Resource Management. IMPORTANT: For Graph API GET requests using advanced query parameters ($filter, $count, $search, $orderby), you are ADVISED to set 'consistencyLevel: \"eventual\"'.", {
     apiType: z.enum(["graph", "azure"]).describe("Type of Microsoft API to query. Options: 'graph' for Microsoft Graph (Entra) or 'azure' for Azure Resource Management."),
     path: z.string().describe("The Azure or Graph API URL path to call (e.g. '/users', '/groups', '/subscriptions')"),
@@ -33,7 +54,8 @@ server.tool("Lokka-Microsoft", "A versatile tool to interact with Microsoft APIs
     graphApiVersion: z.enum(["v1.0", "beta"]).optional().default(defaultGraphApiVersion).describe(`Microsoft Graph API version to use (default: ${defaultGraphApiVersion})`),
     fetchAll: z.boolean().optional().default(false).describe("Set to true to automatically fetch all pages for list results (e.g., users, groups). Default is false."),
     consistencyLevel: z.string().optional().describe("Graph API ConsistencyLevel header. ADVISED to be set to 'eventual' for Graph GET requests using advanced query parameters ($filter, $count, $search, $orderby)."),
-}, async ({ apiType, path, method, apiVersion, subscriptionId, queryParams, body, graphApiVersion, fetchAll, consistencyLevel }) => {
+    tenantId: z.string().optional().describe("Optional Microsoft Entra tenant ID (GUID or domain) to target for this request. When provided, the request acquires an access token for this tenant instead of the default TENANT_ID. Useful for: (1) multi-tenant app-only scenarios (client_credentials/certificate), (2) interactive users who are guests (B2B) in another tenant — note that an additional sign-in prompt may appear if no silent SSO is available. Not supported in client_provided_token mode."),
+}, async ({ apiType, path, method, apiVersion, subscriptionId, queryParams, body, graphApiVersion, fetchAll, consistencyLevel, tenantId }) => {
     // Override graphApiVersion if USE_GRAPH_BETA is explicitly set to false
     const effectiveGraphApiVersion = !useGraphBeta ? "v1.0" : graphApiVersion;
     logger.info(`Executing Lokka-Microsoft tool with params: apiType=${apiType}, path=${path}, method=${method}, graphApiVersion=${effectiveGraphApiVersion}, fetchAll=${fetchAll}, consistencyLevel=${consistencyLevel}`);
@@ -45,9 +67,12 @@ server.tool("Lokka-Microsoft", "A versatile tool to interact with Microsoft APIs
             if (!graphClient) {
                 throw new Error("Graph client not initialized");
             }
+            const effectiveGraphClient = tenantId
+                ? await buildTenantSpecificGraphClient(tenantId)
+                : graphClient;
             determinedUrl = `https://graph.microsoft.com/${effectiveGraphApiVersion}`; // For error reporting
             // Construct the request using the Graph SDK client
-            let request = graphClient.api(path).version(effectiveGraphApiVersion);
+            let request = effectiveGraphClient.api(path).version(effectiveGraphApiVersion);
             // Add query parameters if provided and not empty
             if (queryParams && Object.keys(queryParams).length > 0) {
                 request = request.query(queryParams);
@@ -72,7 +97,7 @@ server.tool("Lokka-Microsoft", "A versatile tool to interact with Microsoft APIs
                             return true; // Return true to continue iteration
                         };
                         // Create a PageIterator starting from the first response
-                        const pageIterator = new PageIterator(graphClient, firstPageResponse, callback);
+                        const pageIterator = new PageIterator(effectiveGraphClient, firstPageResponse, callback);
                         // Iterate over all remaining pages
                         await pageIterator.iterate();
                         // Construct final response with context and combined values under 'value' key
@@ -111,10 +136,16 @@ server.tool("Lokka-Microsoft", "A versatile tool to interact with Microsoft APIs
             if (!authManager) {
                 throw new Error("Auth manager not initialized");
             }
+            if (tenantId) {
+                const mode = authManager.getAuthMode();
+                if (mode === AuthMode.ClientProvidedToken) {
+                    throw new Error("The 'tenantId' parameter is not supported in client_provided_token mode (the supplied token is bound to a single tenant).");
+                }
+            }
             determinedUrl = "https://management.azure.com"; // For error reporting
             // Acquire token for Azure RM
             const azureCredential = authManager.getAzureCredential();
-            const tokenResponse = await azureCredential.getToken("https://management.azure.com/.default");
+            const tokenResponse = await azureCredential.getToken("https://management.azure.com/.default", tenantId ? { tenantId } : undefined);
             if (!tokenResponse || !tokenResponse.token) {
                 throw new Error("Failed to acquire Azure access token");
             }
@@ -155,7 +186,7 @@ server.tool("Lokka-Microsoft", "A versatile tool to interact with Microsoft APIs
                     logger.info(`Fetching Azure RM page: ${currentUrl}`);
                     // Re-acquire token for each page (Azure tokens might expire)
                     const azureCredential = authManager.getAzureCredential();
-                    const currentPageTokenResponse = await azureCredential.getToken("https://management.azure.com/.default");
+                    const currentPageTokenResponse = await azureCredential.getToken("https://management.azure.com/.default", tenantId ? { tenantId } : undefined);
                     if (!currentPageTokenResponse || !currentPageTokenResponse.token) {
                         throw new Error("Failed to acquire Azure access token during pagination");
                     }
@@ -541,10 +572,20 @@ async function main() {
         if (!tenantId || !clientId || !clientSecret) {
             throw new Error("Client credentials mode requires explicit TENANT_ID, CLIENT_ID, and CLIENT_SECRET environment variables");
         }
+        if (tenantId === 'common' || tenantId === 'organizations') {
+            throw new Error(`TENANT_ID value "${tenantId}" is not supported for app-only authentication. ` +
+                "The Microsoft identity platform requires a specific tenant GUID or domain " +
+                "(e.g. 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' or 'contoso.onmicrosoft.com') for client credentials / certificate auth.");
+        }
     }
     else if (authMode === AuthMode.Certificate) {
         if (!tenantId || !clientId || !certificatePath) {
             throw new Error("Certificate mode requires explicit TENANT_ID, CLIENT_ID, and CERTIFICATE_PATH environment variables");
+        }
+        if (tenantId === 'common' || tenantId === 'organizations') {
+            throw new Error(`TENANT_ID value "${tenantId}" is not supported for app-only authentication. ` +
+                "The Microsoft identity platform requires a specific tenant GUID or domain " +
+                "(e.g. 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' or 'contoso.onmicrosoft.com') for client credentials / certificate auth.");
         }
     }
     // Note: Client token mode can start without a token and receive it later

--- a/src/mcp/src/auth.ts
+++ b/src/mcp/src/auth.ts
@@ -136,7 +136,8 @@ export class AuthManager {
         this.credential = new ClientSecretCredential(
           this.config.tenantId,
           this.config.clientId,
-          this.config.clientSecret
+          this.config.clientSecret,
+          { additionallyAllowedTenants: ['*'] }
         );
         break;
 
@@ -153,10 +154,15 @@ export class AuthManager {
           throw new Error("Certificate mode requires tenantId, clientId, and certificatePath");
         }
         logger.info("Initializing Certificate authentication");
-        this.credential = new ClientCertificateCredential(this.config.tenantId, this.config.clientId, {
-          certificatePath: this.config.certificatePath,
-          certificatePassword: this.config.certificatePassword
-        });
+        this.credential = new ClientCertificateCredential(
+          this.config.tenantId,
+          this.config.clientId,
+          {
+            certificatePath: this.config.certificatePath,
+            certificatePassword: this.config.certificatePassword
+          },
+          { additionallyAllowedTenants: ['*'] }
+        );
         break;
 
       case AuthMode.Interactive:
@@ -172,6 +178,7 @@ export class AuthManager {
             tenantId: tenantId,
             clientId: clientId,
             redirectUri: this.config.redirectUri || LokkaDefaultRedirectUri,
+            additionallyAllowedTenants: ['*'],
           });
         } catch (error) {
           // Fallback to Device Code flow
@@ -179,6 +186,7 @@ export class AuthManager {
           this.credential = new DeviceCodeCredential({
             tenantId: tenantId,
             clientId: clientId,
+            additionallyAllowedTenants: ['*'],
             userPromptCallback: (info: DeviceCodeInfo) => {
               console.log(`\n🔐 Authentication Required:`);
               console.log(`Please visit: ${info.verificationUri}`);

--- a/src/mcp/src/main.ts
+++ b/src/mcp/src/main.ts
@@ -29,6 +29,30 @@ const defaultGraphApiVersion = getDefaultGraphApiVersion();
 
 logger.info(`Graph API default version: ${defaultGraphApiVersion} (USE_GRAPH_BETA=${process.env.USE_GRAPH_BETA || 'undefined'})`);
 
+async function buildTenantSpecificGraphClient(tenantId: string): Promise<Client> {
+  if (!authManager) {
+    throw new Error("Auth manager not initialized");
+  }
+  const mode = authManager.getAuthMode();
+  if (mode === AuthMode.ClientProvidedToken) {
+    throw new Error(
+      "The 'tenantId' parameter is not supported in client_provided_token mode (the supplied token is bound to a single tenant)."
+    );
+  }
+  const credential = authManager.getAzureCredential();
+  return Client.initWithMiddleware({
+    authProvider: {
+      getAccessToken: async () => {
+        const token = await credential.getToken("https://graph.microsoft.com/.default", { tenantId });
+        if (!token) {
+          throw new Error(`Failed to acquire Graph token for tenant ${tenantId}`);
+        }
+        return token.token;
+      }
+    }
+  });
+}
+
 server.tool(
   "Lokka-Microsoft",
   "A versatile tool to interact with Microsoft APIs including Microsoft Graph (Entra) and Azure Resource Management. IMPORTANT: For Graph API GET requests using advanced query parameters ($filter, $count, $search, $orderby), you are ADVISED to set 'consistencyLevel: \"eventual\"'.",
@@ -43,6 +67,7 @@ server.tool(
     graphApiVersion: z.enum(["v1.0", "beta"]).optional().default(defaultGraphApiVersion as "v1.0" | "beta").describe(`Microsoft Graph API version to use (default: ${defaultGraphApiVersion})`),
     fetchAll: z.boolean().optional().default(false).describe("Set to true to automatically fetch all pages for list results (e.g., users, groups). Default is false."),
     consistencyLevel: z.string().optional().describe("Graph API ConsistencyLevel header. ADVISED to be set to 'eventual' for Graph GET requests using advanced query parameters ($filter, $count, $search, $orderby)."),
+    tenantId: z.string().optional().describe("Optional Microsoft Entra tenant ID (GUID or domain) to target for this request. When provided, the request acquires an access token for this tenant instead of the default TENANT_ID. Useful for: (1) multi-tenant app-only scenarios (client_credentials/certificate), (2) interactive users who are guests (B2B) in another tenant — note that an additional sign-in prompt may appear if no silent SSO is available. Not supported in client_provided_token mode."),
   },
   async ({
     apiType,
@@ -54,7 +79,8 @@ server.tool(
     body,
     graphApiVersion,
     fetchAll,
-    consistencyLevel
+    consistencyLevel,
+    tenantId
   }: {
     apiType: "graph" | "azure";
     path: string;
@@ -66,6 +92,7 @@ server.tool(
     graphApiVersion: "v1.0" | "beta";
     fetchAll: boolean;
     consistencyLevel?: string;
+    tenantId?: string;
   }) => {
     // Override graphApiVersion if USE_GRAPH_BETA is explicitly set to false
     const effectiveGraphApiVersion = !useGraphBeta ? "v1.0" : graphApiVersion;
@@ -81,10 +108,13 @@ server.tool(
         if (!graphClient) {
           throw new Error("Graph client not initialized");
         }
+        const effectiveGraphClient = tenantId
+          ? await buildTenantSpecificGraphClient(tenantId)
+          : graphClient;
         determinedUrl = `https://graph.microsoft.com/${effectiveGraphApiVersion}`; // For error reporting
 
         // Construct the request using the Graph SDK client
-        let request = graphClient.api(path).version(effectiveGraphApiVersion);
+        let request = effectiveGraphClient.api(path).version(effectiveGraphApiVersion);
 
         // Add query parameters if provided and not empty
         if (queryParams && Object.keys(queryParams).length > 0) {
@@ -114,7 +144,7 @@ server.tool(
               };
 
               // Create a PageIterator starting from the first response
-              const pageIterator = new PageIterator(graphClient, firstPageResponse, callback);
+              const pageIterator = new PageIterator(effectiveGraphClient, firstPageResponse, callback);
 
               // Iterate over all remaining pages
               await pageIterator.iterate();
@@ -155,11 +185,22 @@ server.tool(
         if (!authManager) {
           throw new Error("Auth manager not initialized");
         }
+        if (tenantId) {
+          const mode = authManager.getAuthMode();
+          if (mode === AuthMode.ClientProvidedToken) {
+            throw new Error(
+              "The 'tenantId' parameter is not supported in client_provided_token mode (the supplied token is bound to a single tenant)."
+            );
+          }
+        }
         determinedUrl = "https://management.azure.com"; // For error reporting
 
         // Acquire token for Azure RM
         const azureCredential = authManager.getAzureCredential();
-        const tokenResponse = await azureCredential.getToken("https://management.azure.com/.default");
+        const tokenResponse = await azureCredential.getToken(
+          "https://management.azure.com/.default",
+          tenantId ? { tenantId } : undefined
+        );
         if (!tokenResponse || !tokenResponse.token) {
           throw new Error("Failed to acquire Azure access token");
         }
@@ -204,7 +245,10 @@ server.tool(
           while (currentUrl) {            logger.info(`Fetching Azure RM page: ${currentUrl}`);
             // Re-acquire token for each page (Azure tokens might expire)
             const azureCredential = authManager.getAzureCredential();
-            const currentPageTokenResponse = await azureCredential.getToken("https://management.azure.com/.default");
+            const currentPageTokenResponse = await azureCredential.getToken(
+              "https://management.azure.com/.default",
+              tenantId ? { tenantId } : undefined
+            );
             if (!currentPageTokenResponse || !currentPageTokenResponse.token) {
               throw new Error("Failed to acquire Azure access token during pagination");
             }
@@ -641,9 +685,23 @@ async function main() {
     if (!tenantId || !clientId || !clientSecret) {
       throw new Error("Client credentials mode requires explicit TENANT_ID, CLIENT_ID, and CLIENT_SECRET environment variables");
     }
+    if (tenantId === 'common' || tenantId === 'organizations') {
+      throw new Error(
+        `TENANT_ID value "${tenantId}" is not supported for app-only authentication. ` +
+        "The Microsoft identity platform requires a specific tenant GUID or domain " +
+        "(e.g. 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' or 'contoso.onmicrosoft.com') for client credentials / certificate auth."
+      );
+    }
   } else if (authMode === AuthMode.Certificate) {
     if (!tenantId || !clientId || !certificatePath) {
       throw new Error("Certificate mode requires explicit TENANT_ID, CLIENT_ID, and CERTIFICATE_PATH environment variables");
+    }
+    if (tenantId === 'common' || tenantId === 'organizations') {
+      throw new Error(
+        `TENANT_ID value "${tenantId}" is not supported for app-only authentication. ` +
+        "The Microsoft identity platform requires a specific tenant GUID or domain " +
+        "(e.g. 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' or 'contoso.onmicrosoft.com') for client credentials / certificate auth."
+      );
     }
   }
   // Note: Client token mode can start without a token and receive it later

--- a/website/docs/install-advanced/app-only-auth.md
+++ b/website/docs/install-advanced/app-only-auth.md
@@ -8,6 +8,10 @@ This authentication method uses the client credentials flow to authenticate the 
 
 You can use either certificate (recommended) or client secret authentication with the following configuration. In both instances, you need to create a Microsoft Entra application and grant it the necessary permissions.
 
+:::warning TENANT_ID must be a specific tenant
+The Microsoft identity platform does **not** support `common` or `organizations` as `TENANT_ID` values for app-only (client credentials) authentication. You must provide a specific tenant GUID (e.g. `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) or a verified domain (e.g. `contoso.onmicrosoft.com`). Lokka will refuse to start with `common`/`organizations` in app-only mode.
+:::
+
 ## Create an Entra app for App-Only auth with Lokka
 
 - Open [Entra admin center](https://entra.microsoft.com) > **Identity** > **Applications** > **App registrations**
@@ -74,3 +78,18 @@ You can now configure Lokka in VSCode, Claude using the config below.
   }
 }
 ```
+
+## Querying multiple tenants in a single session
+
+If your Entra application is registered as **multi-tenant** (`Accounts in any organizational directory`) and admin consent has been granted in several tenants, Lokka can query each of them in the same session — no restart required.
+
+The `Lokka-Microsoft` tool exposes an optional `tenantId` parameter. When provided, the request acquires an access token for that specific tenant instead of the default `TENANT_ID`. Just ask the agent in plain language:
+
+> *"Get `/organization` from tenant `contoso.onmicrosoft.com`, then from tenant `fabrikam.onmicrosoft.com`."*
+
+The agent will pass `tenantId` per call and Lokka transparently obtains a token scoped to each target tenant.
+
+**Requirements:**
+- The Entra app must be registered as multi-tenant.
+- Admin consent must be granted in every target tenant.
+- `TENANT_ID` (the default) must still be a specific tenant GUID/domain — it is the home tenant used when no `tenantId` override is provided.

--- a/website/docs/install-advanced/interactive-auth.md
+++ b/website/docs/install-advanced/interactive-auth.md
@@ -53,3 +53,13 @@ The `USE_INTERACTIVE` needs to be set to `true` when using a custom app for inte
     }
   }
 ```
+
+## Guest (B2B) access to other tenants
+
+If your account is a guest (B2B collaboration) in another Microsoft Entra tenant, you can query that tenant directly from the same session — no need to sign out or restart Lokka.
+
+The `Lokka-Microsoft` tool accepts an optional `tenantId` parameter. Ask the agent something like:
+
+> *"Get `/organization` from tenant `contoso.onmicrosoft.com` where I'm a guest."*
+
+Lokka will request a token scoped to that tenant for your user account. Depending on your browser session and SSO state, an additional sign-in prompt may appear the first time you target a new tenant — this is the standard cross-tenant authentication flow and is expected.

--- a/website/docs/install-advanced/readme.md
+++ b/website/docs/install-advanced/readme.md
@@ -14,7 +14,13 @@ Lokka supports multiple authentication options. Here's a quick summary of all th
 - 1️⃣ → [Interactive Auth](interactive-auth)
   - Interactive auth with default app
   - Interactive auth with custom app
+  - Guest (B2B) access to other tenants
 - 2️⃣ → [App-Only Auth](app-only-auth)
   - App-Only Auth with Certificate
   - App-Only Auth with Client Secret
+  - Querying multiple tenants in a single session
 - 3️⃣ → [Token Auth](token-auth)
+
+:::tip Multi-tenant queries
+Lokka supports querying **different tenants in the same session** via the optional `tenantId` parameter on the `Lokka-Microsoft` tool. Available in both interactive (guest/B2B) and app-only (multi-tenant app) modes. See the relevant guide above for details.
+:::


### PR DESCRIPTION
Closes #38.

## Summary

- Multi-tenant Entra apps now work in app-only mode (`ClientCredentials` and `Certificate`). The Azure Identity credentials are constructed with `additionallyAllowedTenants: ['*']` so the same credential can acquire tokens for any tenant the app is consented in. This is the direct fix for #38.
- The `Lokka-Microsoft` tool gains an optional `tenantId` parameter. Within a single session, the agent can query several tenants — useful for multi-tenant app-only scenarios and for interactive users who are guests (B2B) in other tenants.
- App-only mode now refuses to start when `TENANT_ID` is `common` or `organizations`, with a clear error message (Microsoft identity platform does not support these values for the client credentials grant).
- Documentation updated in `website/docs/install-advanced/` and in both READMEs.

## Test plan

- [ ] `npm run build` in `src/mcp` (TypeScript strict, no errors).
- [ ] App-only mode with a multi-tenant app: query `/organization` without `tenantId` (returns home tenant), then with `tenantId=<other>` (returns target tenant).
- [ ] Interactive mode as a B2B guest: query `/organization` with `tenantId=<host-tenant>` succeeds (with a possible interactive sign-in prompt).
- [ ] App-only with `TENANT_ID=common` → server fails to start with the expected error.
- [ ] Client-provided-token mode with `tenantId` parameter → tool returns the explicit "not supported" error.
- [ ] Existing single-tenant flow (no `tenantId` argument) is unaffected.