### PR TITLE
fix: keep native fetch on Node >=18 to avoid node-fetch "Premature close"

### DIFF
--- a/src/mcp/src/main.ts
+++ b/src/mcp/src/main.ts
@@ -8,8 +8,16 @@ import { logger } from "./logger.js";
 import { AuthManager, AuthConfig, AuthMode } from "./auth.js";
 import { LokkaClientId, LokkaDefaultTenantId, LokkaDefaultRedirectUri, getDefaultGraphApiVersion } from "./constants.js";
 
-// Set up global fetch for the Microsoft Graph client
-(global as any).fetch = fetch;
+// Set up global fetch for the Microsoft Graph client.
+// Only polyfill when the runtime has no native fetch (Node < 18). On Node >= 18
+// the native (undici) fetch is present and correct; overwriting it with
+// isomorphic-fetch / node-fetch@2 triggers "Premature close" on Graph responses
+// under Node 24 (node-fetch@2's keep-alive socket lifecycle races the
+// gzip-decompress stream). isomorphic-fetch already guards its own polyfill the
+// same way (`if (!global.fetch)`); mirror that here.
+if (!(globalThis as any).fetch) {
+    (global as any).fetch = fetch;
+}
 
 // Create server instance
 const server = new McpServer({


### PR DESCRIPTION
## Summary

On Node 18+, Lokka overwrites the runtime's native `fetch` with `isomorphic-fetch` (node-fetch@2). Under Node 24 this makes **every** Microsoft Graph call fail with:

```
FetchError: Invalid response body while trying to fetch <url>: Premature close
```

This change guards the polyfill so it only runs when the runtime has no native `fetch` (Node < 18) — matching how `isomorphic-fetch` already guards its own polyfill.

## Symptom

Every Graph request returns `statusCode 200` and then `Premature close` (the response body stream is cut before it finishes), including trivial calls such as `/organization`. Authentication and network egress are fine; only the body stream is dropped.

## Root cause

`src/mcp/src/main.ts`:

```ts
(global as any).fetch = fetch; // isomorphic-fetch -> node-fetch@2
```

This replaces Node's native undici `fetch` with node-fetch@2.7.0. On Node 24, node-fetch@2's keep-alive socket lifecycle races the gzip-decompression stream and throws `Premature close` when the response body is read. Node's built-in undici `fetch` handles the identical request correctly.

`isomorphic-fetch` itself only polyfills when there is no native fetch:

```js
if (!global.fetch) { global.fetch = ...; }
```

Lokka's unconditional assignment defeats that guard on modern Node.

## Evidence (Node v24.17.0, same process, same Graph token)

| fetch implementation | `GET /organization` |
| --- | --- |
| native undici `fetch` | ✅ 200 OK |
| node-fetch@2.7.0 (default) | ❌ Premature close |
| node-fetch@2.7.0 `compress: false` | ✅ OK |
| node-fetch@2.7.0 `keepAlive: false` agent | ✅ OK |

Verified end to end through `Client.initWithMiddleware().api('/organization').get()`: it fails with node-fetch as the global, and succeeds with native fetch.

## Fix

Guard the polyfill so the native fetch is kept on Node ≥18:

```ts
if (!(globalThis as any).fetch) {
    (global as any).fetch = fetch;
}
```

On Node < 18 (no native fetch) behaviour is unchanged: isomorphic-fetch still polyfills.

## Compatibility

The Graph client (`@microsoft/microsoft-graph-client` v3) consumes responses only through its high-level API (`.api().get()/.post()/.delete()`, `PageIterator`) and `Response.text()` / `.json()`, all of which undici implements per the WHATWG fetch spec. There is no raw `response.body` Node-stream usage in the codebase, so moving from node-fetch to native fetch on modern Node is transparent.

## Reproduce

On Node 18+, any app-only or delegated Graph call (for example, a `/organization` query) returns `Premature close` before this change and succeeds after it.
